### PR TITLE
Correctly regex parse Procfile

### DIFF
--- a/lib/procfile.js
+++ b/lib/procfile.js
@@ -9,10 +9,10 @@ function procs(procdata){
     procdata.toString().split(/\n/).forEach(function(line){
         if(line=='') return;
         
-        var tuple = line.trim().split(":",2);
+        var tuple = /^([A-Za-z0-9_]+):\s*(.+)$/.exec(line);
 
-        var prockey = tuple[0].trim();
-        var command = tuple[1].trim();
+        var prockey = tuple[1].trim();
+        var command = tuple[2].trim();
         
         if(prockey=='')
             return cons.Warn('Syntax Error in Procfile, Line %d: No Prockey Found',i+1);


### PR DESCRIPTION
The following valid Procfile:

```
web: PATH=$HUBOT_PATHS:$PATH && bin/hubot --name $HUBOT_USER --adapter $ADAPTER --alias '/'
```

Would incorrectly be part of the UpStart script as

```
exec PATH=$HUBOT_PATHS  >> /opt/hubot/shared/log/sites/hubot/web-1.log 2>&1
```

Instead of the valid

```
exec PATH=$HUBOT_PATHS:$PATH && bin/hubot --name $HUBOT_USER --adapter $ADAPTER --alias '/' >> /opt/hubot/shared/log/sites/hubot/web-1.log 2>&1
```
