### PR TITLE
Windows quote marks

### DIFF
--- a/lib/proc.js
+++ b/lib/proc.js
@@ -24,7 +24,7 @@ function run(key,proc,emitter){
 
     if(platform === 'win32'){
         args.unshift(command);
-        args = ['/C', '"' + args.map(JSON.stringify).join(' ') + '"', '/S'];
+        args = ['/C', args.join(' ')];
         command = 'cmd';
         opts.windowsVerbatimArguments = true;
     }


### PR DESCRIPTION
Ahh.. damn. Just found another windows issue.

So it looks like I may have been too precautions with the windows quote characters (in pull request #17), and if the command gets a bit long it starts to miss some arguments. I've just changed one line slightly.

Sorry to be pain, looks like my testing wasn't didn't account for all the cases :(
