### PR TITLE
Handles Windows Procfiles with CRLF

### DIFF
--- a/lib/procfile.js
+++ b/lib/procfile.js
@@ -9,7 +9,7 @@ function procs(procdata){
     procdata.toString().split(/\n/).forEach(function(line){
         if(line=='') return;
         
-        var tuple = /^([A-Za-z0-9_]+):\s*(.+)$/.exec(line);
+        var tuple = /^([A-Za-z0-9_]+):\s*(.+)$/m.exec(line);
 
         var prockey = tuple[1].trim();
         var command = tuple[2].trim();


### PR DESCRIPTION
- If Procfile has CRLF line endings, line array ends in 
  a trailing \r, which breaks the Regex
- One way to work around this issue is to turn on multiline since
  the lines have already been split into an array

Our Jenkins server is currently Windows based, and we have a Capistrano deploy using the `Jenkins` plugin / scm strategy.

When the files are put into the zip file by Jenkins, the git checkout under windows has `autocrlf` set to true, which turns all text files (like Procfile) into CRLF line endings (based on our `.gitattributes` which sets text files to auto).  When the archive is downloaded from Jenkins and then extracted / pushed back up to the servers, the file arrives with CRLF (regardless if the deploy is initiated from Linux or OSX).  

Unfortunately during the deployment when node-foreman gets its hands on the file, it hasn't been converted back to LF.

I can understand why you might want to reject this... but I think it's an OK solution to prevent this gotcha.
