### PR TITLE
Parse Procfile command with environment variables

### DIFF
--- a/lib/procfile.js
+++ b/lib/procfile.js
@@ -30,38 +30,35 @@ function procs(procdata,envs){
         if(command=='')
             return cons.Warn('Syntax Error in Procfile, Line %d: No Command Found',i+1);
 
-        var comm = command.split(/\s/);
-        var args = comm.splice(1,comm.length);
+        var parts = command.split(/\s/);
 
         // Substitute $variables for their values
         var key, i = 0;
 
-        for (; i < args.length; i++) {
+        for (; i < parts.length; i++) {
           if (envs) {
             for (key in envs) {
-              args[i] = replaceVar(args[i], key, envs[key]);
+              parts[i] = replaceVar(parts[i], key, envs[key]);
             }
           }
 
           // If there's still possibly variables, then use process.env vars
-          if (args[i].indexOf('$') !== -1) {
+          if (parts[i].indexOf('$') !== -1) {
             for (key in _process.env) {
-              args[i] = replaceVar(args[i], key, _process.env[key]);
+              parts[i] = replaceVar(parts[i], key, _process.env[key]);
             }
           }
-          
+
           // Warn on unmatched substitutions
-          if(args[i].match(/^\$\S+/)) cons.Warn('Unresovled Substitution in %s:',prockey,args[i]);
-          
+          if(parts[i].match(/^\$\S+/)) cons.Warn('Unresovled Substitution in %s:',prockey,parts[i]);
         }
 
         var process = {
-            command : comm[0],
-            args    : args
+            command : parts[0],
+            args    : parts.splice(1,parts.length)
         };
-
+        
         processes[prockey]=process;
-
     });
 
     return processes;


### PR DESCRIPTION
Currently Procfile commands only get parsed with environment variables for the commands arguments. For example:

```
.env
WEB=node app.js

Procfile
web: $WEB
```

Doesn't work. This is an edge case, but useful if you want to run `node app.js` in production and `supervisor app.js` in development.

I've changed the parsing to also check the main command, and not just the arguments.
