### PR TITLE
Remove /s flag from cmd.exe for spawn on Windows

### DIFF
--- a/lib/proc.js
+++ b/lib/proc.js
@@ -18,7 +18,7 @@ function run(key,proc,emitter) {
     var file, args;
     if (platform === 'win32') {
         file = process.env.comspec || 'cmd.exe';
-        args = ['/s', '/c', '"' + proc.command + '"'];
+        args = ['/s', '/c', proc.command];
     } else {
         file = '/bin/sh';
         args = ['-c', proc.command];


### PR DESCRIPTION
Possible fix for #50
