### PR TITLE
[api] 	SMF export (for Solaris, Illumos, SmartOS)

### DIFF
--- a/lib/exporters.js
+++ b/lib/exporters.js
@@ -130,6 +130,12 @@ function supervisord_app_n(conf,outdir){
     render(templatePath(conf, 'supervisord', 'foreman-APP-N.conf'), conf, writeout(path) )
 }
 
+function smf_app(conf,outdir){
+    var out = "";
+    var path = outdir + "/" + conf.application + "-" + conf.process + ".xml";
+    render(templatePath(conf, 'smf', 'foreman-APP.xml'), conf, writeout(path) )
+}
+
 export_formats = {
     "upstart": {
         foreman       : upstart,
@@ -150,6 +156,11 @@ export_formats = {
         foreman       : supervisord,
         foreman_app   : function noop() {},
         foreman_app_n : supervisord_app_n,
+    },
+    "smf": {
+        foreman       : function noop() {},
+        foreman_app   : smf_app,
+        foreman_app_n : function noop() {},
     },
 }
 

--- a/lib/smf/foreman-APP.xml
+++ b/lib/smf/foreman-APP.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<service_bundle type="manifest" name="{{{application}}}">
+  <service name="site/{{{application}}}" type="service" version="1">
+
+    <create_default_instance enabled="true"/>
+
+    <single_instance/>
+
+    <dependency name="network" grouping="require_all" restart_on="refresh" type="service">
+      <service_fmri value="svc:/milestone/network:default"/>
+    </dependency>
+
+    <dependency name="filesystem" grouping="require_all" restart_on="refresh" type="service">
+      <service_fmri value="svc:/system/filesystem/local"/>
+    </dependency>
+
+    <method_context working_directory="{{{cwd}}}">
+      <method_credential user="{{{user}}}" group="{{{group}}}" privileges="basic,net_privaddr"/>
+      <method_environment>
+        {{#envs}}<envvar name="{{{key}}}" value="{{{value}}}"/>
+        {{/envs}}
+      </method_environment>
+    </method_context>
+
+    <exec_method
+      type="method"
+      name="start"
+      exec="{{{command}}}"
+      timeout_seconds="60"/>
+
+    <exec_method
+      type="method"
+      name="stop"
+      exec=":kill"
+      timeout_seconds="60"/>
+
+    <property_group name="startd" type="framework">
+      <propval name="duration" type="astring" value="child"/>
+      <propval name="ignore_error" type="astring" value="core,signal"/>
+    </property_group>
+
+    <property_group name="application" type="application">
+
+    </property_group>
+
+
+    <stability value="Evolving"/>
+
+    <template>
+      <common_name>
+        <loctext xml:lang="C">{{{application}}}</loctext>
+      </common_name>
+    </template>
+
+  </service>
+
+</service_bundle>


### PR DESCRIPTION
Initial support for exporting to Service Management Facility XML format.  This template has all the necessary parts to run a nodejs application as a service.  I am using this now on SmartOS on Joyent Cloud.

This is basically the template that Manifold uses to create SMF manifests for web services:
http://wiki.joyent.com/wiki/display/jpc2/Building+Manifests+with+manifold
With additional properties as suggested by Joyent docs and example:
https://github.com/isaacs/joyent-node-on-smart-example/blob/master/node-hello-world-service-manifest.xml

Right now I have only created the single-instance template.  Multiple instances are handled in a single file in SMF, further alteration would be required to node-foreman core to write the multiple instance tags into a template.

Also, multiple instance SMF is poorly documented.  Appreciate suggestions from any experienced Solaris users on the correct way to build that out.
