### PR TITLE
Fix #57 -- Proxy error under MS Windows...

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -38,7 +38,7 @@ http.createServer(function (req, res) {
 	addresses.push(target);
 	
 }).listen(port,function(){
-	if(process.platform.substring(0,3) !== 'win') {
+	if(process.platform !== 'win32') {
 		if(process.getuid()==0) process.setuid( process.env.SUDO_USER );
 	}
 })


### PR DESCRIPTION
This is a fix for #57 -- "Proxy error under MS Windows - Object #<process> has no method 'getuid'".

The substring call has been removed as requested. My original reason for it was to make the fix resilent to added MS Windows platforms (e.g., in the future there might be a 'win64' or 'winarm').
