### PR TITLE
Add a -d / --indent option to preserve indentation in the output.

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -37,6 +37,7 @@ function Console(logger) {
 
 	this.trimline  = 10
 	this.wrapline = 500
+  this.indent = false
 
 	this.fmt = function fmt(){
 	    return util.format.apply(null,arguments);
@@ -89,7 +90,8 @@ function Console(logger) {
 			}
 
 			wrap(line,wrapline).forEach(function(l){
-				logger.log(proc.color(self.pad(stamp,self.padding) + delimiter),l.trim());
+        if (!self.indent) l = l.trim()
+				logger.log(proc.color(self.pad(stamp,self.padding) + delimiter),l);
 				delimiter = " |  > "
 			})
 

--- a/nf.js
+++ b/nf.js
@@ -61,6 +61,7 @@ program
 .option('-i, --intercept <HOSTNAME>' ,'set forward proxy to intercept HOSTNAME',null)
 .option('-t, --trim      <N>'        ,'trim logs to N characters',0)
 .option('-w, --wrap'                 ,'wrap logs (negates trim)')
+.option('-d, --indent'               ,'preserve indentation in log output')
 .description('Start the jobs in the Procfile')
 .action(function(command_left,command_right){
 
@@ -92,6 +93,11 @@ program
 			display.Alert('Trimming display Output to %d Columns',display.trimline)
 		}
 	}
+
+  if(command.indent){
+    display.indent = true
+    display.Alert('Preserving indentation in Output')
+  }
 
 	if(command.forward) startForward(command.forward,command.intercept,emitter)
 


### PR DESCRIPTION
 Defaults to false to preserve backward compatibility.