### PR TITLE
Lint in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ node_js:
   - "0.12"
   - "0.11"
   - "0.10"
-  - "0.8"
-  - "0.6"
+script: npm run travis

--- a/lib/envs.js
+++ b/lib/envs.js
@@ -8,7 +8,7 @@ function method(name) {
 }
 
 // Parse a Key=Value File Containing Environmental Variables
-function KeyValue(data) {
+function keyValue(data) {
   var env = {};
 
   data
@@ -130,7 +130,7 @@ function loadEnvs(path) {
       env = flattenJSON(envs_json, "", {});
       cons.Alert("Loaded ENV %s File as JSON Format", path);
     } catch (e) {
-      env = KeyValue(data);
+      env = keyValue(data);
       cons.Alert("Loaded ENV %s File as KEY=VALUE Format", path);
     }
   }
@@ -140,5 +140,5 @@ function loadEnvs(path) {
 
 module.exports.loadEnvs = loadEnvs;
 module.exports.flattenJSON = flattenJSON;
-module.exports.KeyValue = KeyValue;
+module.exports.keyValue = keyValue;
 module.exports.dumpEnv  = dumpEnv;

--- a/nf.js
+++ b/nf.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-var util    = require('util');
 var path    = require('path');
 var events  = require('events');
 var fs      = require('fs');
@@ -32,7 +31,6 @@ var start = _proc.start;
 var once  = _proc.once;
 
 var _procfile = require('./lib/procfile');
-var procs     = _procfile.procs;
 var loadProc  = _procfile.loadProc;
 
 var _envs    = require('./lib/envs');
@@ -200,6 +198,7 @@ program
     var baseport = parseInt(program.port || envs.PORT || process.env.PORT || 5000);
     var baseport_i = 0;
     var baseport_j = 0;
+    var envl = [];
 
     config.processes = [];
 
@@ -237,7 +236,7 @@ program
 
         conf.port = baseport + baseport_i + baseport_j * 100;
 
-        var envl = [];
+        envl = [];
         for(key in envs) {
           envl.push({
             key: key,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "nf": "nf.js"
   },
   "scripts": {
-    "test": "tap test"
+    "test": "tap test",
+    "lint": "jshint *.js lib/*.js",
+    "travis": "npm test && npm run lint"
   },
   "dependencies": {
     "commander": "~2.1.0",
@@ -37,8 +39,9 @@
   },
   "preferGlobal": true,
   "devDependencies": {
-    "tap": "~0.4.8",
     "chai": "~1.9.1",
-    "rimraf": "~2.2.8"
+    "jshint": "^2.6.3",
+    "rimraf": "~2.2.8",
+    "tap": "~0.4.8"
   }
 }

--- a/test/envs-commented.test.js
+++ b/test/envs-commented.test.js
@@ -13,9 +13,9 @@ var input = '### This is a config file...\n' +
 
 var expected = 'setting=important\n'
 
-var loadedEnv = envs.KeyValue(input)
+var loadedEnv = envs.keyValue(input)
 var dumpedEnv = envs.dumpEnv(loadedEnv)
-var loadedFlat = envs.KeyValue(expected)
+var loadedFlat = envs.keyValue(expected)
 var dumpedFlat = envs.dumpEnv(loadedFlat)
 assert.equal(dumpedEnv, expected)
 assert.equal(dumpedFlat, expected)

--- a/test/envs-empty.test.js
+++ b/test/envs-empty.test.js
@@ -4,7 +4,7 @@ var assert = require('assert')
 var emptyEnvs = ['', '\n', ' \n \n \n']
 
 emptyEnvs.forEach(function (env) {
-  var loaded = envs.KeyValue(env)
+  var loaded = envs.keyValue(env)
   // {} == {}
   assert.equal(Object.keys(loaded).length, 0)
 })

--- a/test/envs-quoted.test.js
+++ b/test/envs-quoted.test.js
@@ -1,7 +1,7 @@
 var assert = require('assert')
   , envs   = require('../lib/envs')
 
-var parsedHash = envs.KeyValue(
+var parsedHash = envs.keyValue(
   '#commented heading. \n' +
   'key = "quoted#hash" \n' +
   'key2 = stripped#comment \n' +


### PR DESCRIPTION
I added lint in travis feature. But, jshint is not support Node.js 0.6.x and 0.8.x. Test will fail when jshint  install. In my opinion, old version(like 0.6, 0.8) is no need to CI.

Thanks