### PR TITLE
update `http-proxy`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foreman",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "homepage": "http://strongloop.github.io/node-foreman/",
   "description": "Node Implementation of Foreman",
   "author": "StrongLoop, Inc.",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "commander": "~2.1.0",
-    "http-proxy": "~1.0.3",
+    "http-proxy": "~1.11.1",
     "mu2": "~0.5.20",
     "shell-quote": "~1.4.2"
   },


### PR DESCRIPTION
foreman/package.json

    “http-proxy”: “~1.0.3”

http-proxy/package.json

    “eventemitter3”: “*”

`eventemitter3` changed public api so `http-proxy 1.0.3` is broken now
everything is fine with latest `http-proxy 1.11.1` package