### PR TITLE
Alias -j flag to -f

### DIFF
--- a/nf.js
+++ b/nf.js
@@ -13,6 +13,7 @@ var nf = require('./package.json');
 
 program.version(nf.version);
 program.option('-j, --procfile <FILE>' ,'load procfile FILE','Procfile');
+program.option('-f, --procfile <FILE>' ,'load procfile FILE (alias for -j)','Procfile');
 program.option('-e, --env      <FILE>' ,'use FILE to load environment','.env');
 program.option('-p, --port     <PORT>' ,'start indexing ports at number PORT',0);
 


### PR DESCRIPTION
In #1, the option to specify a Procfile was set to `-j`.

That may have been the same option the foreman gem used at the time, but as far back as I can find the option for this has been `-f`, not `-j`.

This PR aliases the `-j` flag to `-f`, allowing a user of node-foreman to use either flag interchangeably.  That means that these all behave similarly:

```
foreman start -f Procfile.dev
nf start -j Procfile.dev
nf start -f Procfile.dev
```