### PR TITLE
Add wrap-width <N> argument to start

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -3,7 +3,8 @@ var colors = require('./colors');
 
 function wrap(log, length, res) {
   if(!res) { res = []; }
-  if(log.length <= length) {
+
+  if(log.length <= length || Number(length) === 0) {
     res.push(log);
     return res;
   } else {
@@ -53,6 +54,7 @@ function Console(logger) {
   };
 
   this.trim = trim;
+  this.wrap = wrap;
 
   // Process Specific Loggers //
   this.info = function info(key, proc, string) {

--- a/nf.js
+++ b/nf.js
@@ -59,7 +59,8 @@ program
   .option('-f, --forward   <PORT>'     ,'start a forward proxy on PORT')
   .option('-i, --intercept <HOSTNAME>' ,'set forward proxy to intercept HOSTNAME',null)
   .option('-t, --trim      <N>'        ,'trim logs to N characters',0)
-  .option('-w, --wrap'                 ,'wrap logs (negates trim)')
+  .option('-w, --wrap'                 ,'wrap logs (negates trim)',0)
+  .option('--wrap-width    <N>'        ,'wrap logs to N characters')
   .description('Start the jobs in the Procfile')
   .action(function(command_left, command_right) {
 
@@ -81,8 +82,8 @@ program
 
     display.padding  = calculatePadding(reqs);
 
-    if(command.wrap) {
-      display.wrapline = process.stdout.columns - display.padding - 7;
+    if(command.wrap || command.wrapWidth) {
+      display.wrapline = command.wrapWidth || process.stdout.columns - display.padding - 7;
       display.trimline = 0;
       display.Alert('Wrapping display Output to %d Columns', display.wrapline);
     } else {

--- a/nf.js
+++ b/nf.js
@@ -85,7 +85,9 @@ program
     if(command.wrap || command.wrapWidth) {
       display.wrapline = command.wrapWidth || process.stdout.columns - display.padding - 7;
       display.trimline = 0;
-      display.Alert('Wrapping display Output to %d Columns', display.wrapline);
+      if(display.wrapline > 0){
+        display.Alert('Wrapping display Output to %d Columns', display.wrapline);
+      }
     } else {
       display.trimline = command.trim || process.stdout.columns - display.padding - 5;
       if(display.trimline > 0){

--- a/test/console-wrap.test.js
+++ b/test/console-wrap.test.js
@@ -1,0 +1,6 @@
+var assert = require('chai').assert
+  , Console = require('../lib/console').Console
+
+assert.deepEqual(['foo ', 'bar ', 'biz '], Console.wrap('foo bar biz ', 4))
+assert.deepEqual(['foo bar biz '], Console.wrap('foo bar biz ', 500))
+assert.deepEqual(['foo bar biz '], Console.wrap('foo bar biz ', 0))


### PR DESCRIPTION
This pull request adds a wrap-width argument to start so that the wrapping with can be set with an arg.  We would like this functionality to be able to turn off wrapping using `--wrap-width 0` to fix an [issue](https://github.com/heroku/toolbelt/issues/157) that we have with backwards compatibility after switching to node-foreman.  If you want me to change or add anything, please let me know.