### PR TITLE
disable black/white colors

### DIFF
--- a/lib/colors.js
+++ b/lib/colors.js
@@ -1,21 +1,17 @@
 var reset = '\x1B[0m';
 var colors = {
-  black:           '\x1B[30m',
   red:             '\x1B[31m',
   green:           '\x1B[32m',
   yellow:          '\x1B[33m',
   blue:            '\x1B[34m',
   magenta:         '\x1B[35m',
   cyan:            '\x1B[36m',
-  white:           '\x1B[37m',
-  bright_black:    '\x1B[30m',
   bright_red:      '\x1B[31m',
   bright_green:    '\x1B[32m',
   bright_yellow:   '\x1B[33m',
   bright_blue:     '\x1B[34m',
   bright_magenta:  '\x1B[35m',
   bright_cyan:     '\x1B[36m',
-  bright_white:    '\x1B[37m',
 };
 
 function identity(self) {

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -1,17 +1,17 @@
 var reset = '\x1B[0m';
 var colors = {
-  red:             '\x1B[31m',
+  magenta:         '\x1B[35m',
+  blue:            '\x1B[34m',
+  cyan:            '\x1B[36m',
   green:           '\x1B[32m',
   yellow:          '\x1B[33m',
-  blue:            '\x1B[34m',
-  magenta:         '\x1B[35m',
-  cyan:            '\x1B[36m',
-  bright_red:      '\x1B[31m',
-  bright_green:    '\x1B[32m',
-  bright_yellow:   '\x1B[33m',
-  bright_blue:     '\x1B[34m',
+  red:             '\x1B[31m',
   bright_magenta:  '\x1B[35m',
   bright_cyan:     '\x1B[36m',
+  bright_blue:     '\x1B[34m',
+  bright_green:    '\x1B[32m',
+  bright_yellow:   '\x1B[33m',
+  bright_red:      '\x1B[31m',
 };
 
 function identity(self) {


### PR DESCRIPTION
these are hard (if even possible) to read when they match the terminal background:

![fcfaf950-fb58-11e5-8b2d-dc971af5bc45](https://cloud.githubusercontent.com/assets/216188/14303077/39ec3c36-fb5c-11e5-82a2-b2217de455b9.png)

also reordered the colors a bit so that red isn't first (since red is better saved for errors)