### PR TITLE
fix 'nf' command name

### DIFF
--- a/lib/procfile.js
+++ b/lib/procfile.js
@@ -1,5 +1,6 @@
 var fs   = require('fs');
 var cons = require('./console').Console;
+var path = require('path');
 
 // Parse Procfile
 function procs(procdata){
@@ -29,10 +30,10 @@ function procs(procdata){
 }
 
 // Look for a Procfile at the Specified Location
-function loadProc(path) {
+function loadProc(filename) {
 
   try {
-    var data = fs.readFileSync(path);
+    var data = fs.readFileSync(filename);
     return procs(data);
   } catch(e) {
     cons.Warn('No Procfile Found');
@@ -40,7 +41,7 @@ function loadProc(path) {
       cons.Alert("package.json file found - trying 'npm start'");
       return procs("web: npm start");
     } else {
-      cons.Error("No Procfile found in Current Directory - See nf --help");
+      cons.Error("No Procfile found in Current Directory - See " + path.basename(process.argv[1]) + " --help");
       return;
     }
   }


### PR DESCRIPTION
this is only really an issue for heroku local, it allows me to do this by setting `process.argv`:

```
$ nf start
[WARN] No ENV file found
[WARN] No Procfile Found
[FAIL] No Procfile found in Current Directory - See nf --help
$ heroku local
[WARN] No ENV file found
[WARN] No Procfile Found
[FAIL] No Procfile found in Current Directory - See heroku local --help
```

but there might be other reasons why the bin is not `nf`