### PR TITLE
improve error messages when loading a procfile

### DIFF
--- a/lib/procfile.js
+++ b/lib/procfile.js
@@ -15,11 +15,11 @@ function procs(procdata){
     var command = tuple[2].trim();
 
     if(!prockey) {
-      return cons.Warn('Syntax Error in Procfile, Line %d: No Prockey Found');
+      throw new Error('Syntax Error in Procfile, Line %d: No Prockey Found');
     }
 
     if(!command) {
-      return cons.Warn('Syntax Error in Procfile, Line %d: No Command Found');
+      throw new Error('Syntax Error in Procfile, Line %d: No Command Found');
     }
 
     processes[prockey] = command;
@@ -35,12 +35,12 @@ function loadProc(path) {
     var data = fs.readFileSync(path);
     return procs(data);
   } catch(e) {
-    cons.Warn('No Procfile Found');
+    cons.Warn(e.message);
     if(fs.existsSync('package.json')) {
       cons.Alert("package.json file found - trying 'npm start'");
       return procs("web: npm start");
     } else {
-      cons.Error("No Procfile found in Current Directory - See nf --help");
+      cons.Error("No Procfile and no package.json file found in Current Directory - See nf --help");
       return;
     }
   }


### PR DESCRIPTION
Currently `nf start` will say "cannot find Procfile" if the Procfile is not found or if there were errors in the Procfile. This eliminates some confusion surrounding that.