### PR TITLE
clean up CLI argument handling

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -9,11 +9,11 @@ function f(key, j, ports, proc, reqs, portargs, localhost, emitter, ssl) {
   var port = parseInt(ports[j]);
   var ssl_port = (port === 80 ? 443 : (port + 443));
 
-  if(port < 1024 && process.getuid() !== 0) {
+  if(port > 0 && port < 1024 && process.getuid() !== 0) {
     return cons.Error('Cannot Bind to Privileged Port %s Without Permission - Try \'sudo\'',port);
   }
 
-  if(!port) {
+  if(isNaN(port)) {
     return cons.Warn('No Downstream Port Defined for \'%s\' Proxy', key);
   }
 
@@ -24,7 +24,7 @@ function f(key, j, ports, proc, reqs, portargs, localhost, emitter, ssl) {
   var upstream_size = reqs[key];
   var upstream_port = parseInt(portargs) + j * 100;
 
-  var proxy = prog.fork(__dirname + '/../proxy.js', [], {
+  var proxy = prog.fork(require.resolve('../proxy'), [], {
     env: {
       HOST: localhost,
       PORT: port,
@@ -33,7 +33,7 @@ function f(key, j, ports, proc, reqs, portargs, localhost, emitter, ssl) {
       UPSTREAM_SIZE: upstream_size,
       SSL_CERT: ssl.cert,
       SSL_KEY: ssl.key,
-      SSL_PORT: ssl_port
+      SSL_PORT: port ? ssl_port : 0
     }
   });
 
@@ -50,6 +50,15 @@ function f(key, j, ports, proc, reqs, portargs, localhost, emitter, ssl) {
     cons.Alert('Starting Secure Proxy Server [%s] %s -> %s', key, ssl_port, port_targets);
   }
 
+  proxy.on('message', function(msg) {
+    if ('http' in msg) {
+      emitter.emit('http', msg.http);
+    }
+    if ('https' in msg) {
+      emitter.emit('https', msg.https);
+    }
+  });
+
   emitter.once('killall', function(signal) {
     cons.Done('Killing Proxy Server on Port %s', port);
     proxy.kill(signal);
@@ -63,7 +72,7 @@ function f(key, j, ports, proc, reqs, portargs, localhost, emitter, ssl) {
 
 function startProxies(reqs, proc, command, emitter, portargs) {
 
-  if(command.proxy){
+  if ('proxy' in command) {
 
     var localhost = 'localhost';
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "tap test/*.test.*"
   },
   "dependencies": {
-    "commander": "~2.1.0",
+    "commander": "~2.9.0",
     "http-proxy": "~1.11.1",
     "mu2": "~0.5.20",
     "shell-quote": "~1.4.2"

--- a/proxy.js
+++ b/proxy.js
@@ -46,7 +46,9 @@ http.createServer(function (req, res) {
 
   addresses.push(target);
 
-}).listen(port);
+}).listen(port, function() {
+  process.send({http: this.address().port});
+});
 
 if (sslCert && sslKey) {
   https.createServer({
@@ -61,5 +63,7 @@ if (sslCert && sslKey) {
 
     addresses.push(target);
 
-  }).listen(sslPort);
+  }).listen(sslPort, function() {
+    process.send({https: this.address().port});
+  });
 }

--- a/test/server.js
+++ b/test/server.js
@@ -34,7 +34,7 @@ module.exports.startServer = function startServer(port, emitter) {
     });
   });
 
-  server.listen(port);
+  server.listen(port, '127.0.0.1');
 
   emitter.once('killall', function () {
     server.close();


### PR DESCRIPTION
Fix how commander.js API is used, checking for positional arguments in the right place. This should fix #89.

Also fix how arguments are counted for determining whether or not to show the 'Foreman' banner.