### PR TITLE
update to support node v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "6"
   - "5"
   - "4"
   - "0.12"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   matrix:
+    - nodejs_version: '6'
     - nodejs_version: '5'
     - nodejs_version: '4'
     - nodejs_version: '0.12'

--- a/lib/exporters.js
+++ b/lib/exporters.js
@@ -1,22 +1,18 @@
 var colors  = require('./colors');
 var ppath   = require('path');
-var mu      = require('mu2');
+var mu      = require('mustache');
 var fs      = require('fs');
 
 var display = require('./console').Console;
 
 // Procfile to System Service Export //
 
-mu.root = __dirname;
-
 function render(filename, conf, callback) {
-  var out = "";
-  var muu = mu.compileAndRender(filename, conf);
-  muu.on('data', function (data) {
-    out += data;
-  });
-  muu.on('end', function(){
-    callback(out);
+  fs.readFile(filename, {encoding: 'utf8'}, function(err, template) {
+    if (err) {
+      throw err;
+    }
+    callback(mu.render(template, conf));
   });
 }
 

--- a/lib/upstart-single/foreman-APP.conf
+++ b/lib/upstart-single/foreman-APP.conf
@@ -16,6 +16,7 @@ respawn
 {{#envs}}env {{{key}}}="{{{value}}}"
 {{/envs}}
 
+
 # Not supported by older versions of Upstart, like on RHEL/CentOS
 chdir {{{cwd}}}
 setuid {{{user}}}

--- a/lib/upstart/foreman-APP-N.conf
+++ b/lib/upstart/foreman-APP-N.conf
@@ -6,6 +6,7 @@ respawn
 {{#envs}}env {{{key}}}="{{{value}}}"
 {{/envs}}
 
+
 chdir {{{cwd}}}
 setuid {{{user}}}
 setgid {{{group}}}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "commander": "~2.9.0",
     "http-proxy": "~1.11.1",
-    "mu2": "~0.5.20",
+    "mustache": "^2.2.1",
     "shell-quote": "~1.4.2"
   },
   "repository": {

--- a/test/fixtures/upstart-custom-templates/foreman-APP-N.conf
+++ b/test/fixtures/upstart-custom-templates/foreman-APP-N.conf
@@ -6,6 +6,7 @@ respawn
 {{#envs}}env {{{key}}}="{{{value}}}"
 {{/envs}}
 
+
 chdir {{{cwd}}}
 setuid {{{user}}}
 setgid {{{group}}}


### PR DESCRIPTION
This will resolve #111.
 * [x] enable node v6 on CI
 * [x] replace `mu2` with another mustache implementation that works on node 6.
 * [x] ~~TBD: I'm sure there will be more than mu2 to fix.~~
   * mu2 ended up being the only thing that was obviously broken ¯\\\_(ツ)\_/¯