### PR TITLE
Remove extra linefeed from raw output

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -74,7 +74,7 @@ function Console(logger) {
     var self = this;
 
     if(self.raw) {
-      logger.log(string);
+      logger.log(string.slice(0,-1));
       return;
     }
 

--- a/lib/console.js
+++ b/lib/console.js
@@ -74,7 +74,10 @@ function Console(logger) {
     var self = this;
 
     if(self.raw) {
-      logger.log(string.slice(0,-1));
+      if (string.slice(-1,0) === '\n') {
+        string = string.slice(0,-1);
+      }
+      logger.log(string);
       return;
     }
 


### PR DESCRIPTION
Remove the extra linefeed from output when using raw.

The problem is that any console output automatically adds a linefeed to the end of the string.
Then your code calls console.log() which adds another linefeed.

The reason this isn't a problem with non raw format is that you do a trim right.