### PR TITLE
Use consistent time format for console output

### DIFF
--- a/lib/console.js
+++ b/lib/console.js
@@ -48,6 +48,10 @@ function Console(logger) {
     return util.format.apply(null, arguments);
   };
 
+  this.dateFmt = function dateFmt(date) {
+    return date.toISOString().replace(/^.*T([^.]*).*$/, "$1");
+  };
+
   this.pad = function pad(string, n) {
     var l = string.length;
     var o = string;
@@ -61,12 +65,12 @@ function Console(logger) {
 
   // Process Specific Loggers //
   this.info = function info(key, proc, string) {
-    var stamp = (new Date().toLocaleTimeString()) + " " + key;
+    var stamp = this.dateFmt(new Date()) + " " + key;
     logger.log(proc.color(this.pad(stamp,this.padding)), colors.cyan(string));
   };
 
   this.error = function error(key, proc, string) {
-    var stamp = (new Date().toLocaleTimeString()) + " " + key;
+    var stamp = this.dateFmt(new Date()) + " " + key;
     logger.error(proc.color(this.pad(stamp,this.padding)), colors.red(string));
   };
 
@@ -82,7 +86,7 @@ function Console(logger) {
 
       if (line.trim().length === 0) { return; }
 
-      var stamp = (new Date().toLocaleTimeString()) + " " + key;
+      var stamp = self.dateFmt(new Date()) + " " + key;
 
       if(self.trimline>0){
         line = self.trim(line,self.trimline);


### PR DESCRIPTION
Looking at the [original implementation](https://github.com/ddollar/foreman/blob/c0b178c164396d6afe6fc3874abfd22f6cddbeae/lib/foreman/engine/cli.rb#L60) as well as the screenshots and terminal output samples within the project's README.md file, it is likely that prefixing the terminal output lines with a time formatted like `%H:%M:%S` is the preferable thing to do.

Currently, however, the `toLocaleTimeString` function is used to format the time which results in the log output prefix to be locale dependent. With `en_US.UTF-8` for example, over here I get `2:02:34 AM` as the prefix.

This pull request corrects the prefix to contain a stable time formatting by using the time part of the string returned by the `toISOString` method instead.