### PR TITLE
Only raise a warning, not an error for privileged ports

### DIFF
--- a/lib/proc.js
+++ b/lib/proc.js
@@ -107,8 +107,8 @@ function start(procs, requirements, envs, portarg, emitter){
   var port = parseInt(portarg);
 
   if(port < 1024) {
-    return cons.Error('Only Proxies Can Bind to Privileged Ports - '+
-                      'Try \'sudo nf start -x %s\'', port);
+    cons.Warn('May Not Be Able To Bind to Privileged Port - '+
+                      'If Start Fails Try \'sudo nf start -x %s\'', port);
   }
 
 


### PR DESCRIPTION
On MacOS, on Linux if using `authbind`, and maybe other cases I don't know about, you don't actually need to use sudo to bind to ports < 1024. However when I try to bind to port 80, Node Foreman raises an error. If I prevent Node Foreman from throwing an error it works fine.

Since we can't detect if this system will or will not require sudo we can just raise a warning instead. We _could_ omit the warning entirely but it might be harder to diagnose the issue if you your system does require sudo?

The use case for me is running a local webserver on port 80 and not having to enter a sudo password every time or unnecessarily elevate permissions.

I've been working around the issue by using a different environment variable to pass the PORT through, but that's pretty confusing for everyone else on the team 😁

I'm having trouble finding a reference for the MacOS guidelines; this is the best I could find: https://news.ycombinator.com/item?id=18302380