### PR TITLE
Spawn children in their own process groups, and deliver SIGINT to each group

### DIFF
--- a/lib/proc.js
+++ b/lib/proc.js
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+var process    = require('process');
 var prog       = require('child_process');
 
 var cons       = require('./console').Console;
@@ -28,7 +29,10 @@ function run(key, proc, emitter) {
     file = '/bin/sh';
     args = ['-c', proc.command];
   }
-  var child = prog.spawn(file, args, { env: proc.env });
+  var child = prog.spawn(file, args, {
+    env: proc.env,
+    detached: true,
+  });
   var killallReceived = false;
 
   child.stdout.on('data', function(data) {
@@ -59,7 +63,11 @@ function run(key, proc, emitter) {
     killallReceived = true;
 
     try {
-      child.kill(signal);
+      if (platform === 'win32') {
+        child.kill(signal);
+      } else {
+        process.kill(-child.pid, signal);
+      }
     }
     catch (err) {
       if (err.code === 'EPERM') {

--- a/nf.js
+++ b/nf.js
@@ -46,8 +46,12 @@ var calculatePadding = _requirements.calculatePadding;
 var startProxies = require('./lib/proxy').startProxies;
 var startForward = require('./lib/forward').startForward;
 
+var interrupted = false;
+
 // Kill All Child Processes on SIGINT
-process.once('SIGINT', function() {
+process.on('SIGINT', function() {
+  if (interrupted) return;
+  interrupted = true;
   display.Warn('Interrupted by User');
   emitter.emit('killall', 'SIGINT');
 });

--- a/test/process-groups.test.sh
+++ b/test/process-groups.test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+NF="node ../nf.js"
+
+rm -rf sandbox
+mkdir -p sandbox
+
+cat << EOF > sandbox/Procfile
+a: sleep 1
+b: /bin/sh -c "sleep 10000 && exit 1"
+EOF
+
+# We'll exit with a code that cannot be used as a signal. This exposes a
+# potential bug in termination handling.
+$NF --procfile sandbox/Procfile start >sandbox/groups.txt 2>&1 && exit 0
+exit 1


### PR DESCRIPTION
This change fixes the issue described in https://github.com/strongloop/node-foreman/issues/176 by:

1. Making `nf` spawn each child process in its own distinct process group via the `detached` option
2. Delivering `SIGINT` signals to children to the entire process group, rather than just the direct child
3. Ensuring that `nf` can handle the delivery of multiple consecutive `SIGINT` signals to itself without exiting prematurely

Changes 1 & 2 are inspired by the approach taken by [goreman](https://github.com/mattn/goreman) (a similar tool implemented in Go). Change 3 is somewhat unrelated, but was added in order to deal with the problem described in https://github.com/pnpm/pnpm/issues/7374 (sometimes, a parent process of `nf` might itself forward a `SIGINT` to `nf`, and the terminal might *also* deliver that signal).