### PR TITLE
fix: replace deprecated util._extend with Object.assign

### DIFF
--- a/lib/envs.js
+++ b/lib/envs.js
@@ -4,7 +4,6 @@
 // License text available at https://opensource.org/licenses/MIT
 
 var fs   = require('fs');
-var util = require('util');
 var cons = require('./console').Console;
 
 function method(name) {
@@ -144,7 +143,7 @@ function loadEnvsFile(path) {
 }
 
 function loadEnvs(path) {
-  var envs = path.split(',').map(loadEnvsFile).reduce(util._extend, {});
+  var envs = path.split(',').map(loadEnvsFile).reduce(Object.assign, {});
   var sorted = Object.create(null);
   Object.keys(envs).sort().forEach(function(k) {
     sorted[k] = envs[k];


### PR DESCRIPTION
The `util._extend` API triggers a DeprecationWarning (DEP0060) on recent versions of Node.js. `Object.assign` has identical semantics and is the recommended replacement. Removes the now-unused `util` import.

Fixes #180